### PR TITLE
Handling exit status 4 from iptables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: build
 build:
-	GOOS=linux CGO_ENABLED=false go build -ldflags=-w -o=./dist/rancher-desktop-guestagent ./cmd/rancher-desktop-guestagent/
+	GOOS=linux CGO_ENABLED=0 go build -ldflags=-w -o=./dist/rancher-desktop-guestagent ./cmd/rancher-desktop-guestagent/


### PR DESCRIPTION
This is a resource error and can happen when multiple things
try to use iptables at the same time. Handling in a fault
tolerant manner.