### PR TITLE
GitHub workflows: disable CGO.

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -22,6 +22,8 @@ jobs:
 
     # Run `go build` to cache things for the linter, so it doesn't time out.
     - run: go build -v ./...
+      env:
+        CGO_ENABLED: '0'
 
     - uses: golangci/golangci-lint-action@v3.1.0
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,8 @@ jobs:
       with:
         go-version-file: go.mod
     - run: go build -v -trimpath ./cmd/rancher-desktop-guestagent
+      env:
+        CGO_ENABLED: '0'
     - run: >-
         tar -czf rancher-desktop-guestagent-${{ github.ref_name }}.tar.gz
         rancher-desktop-guestagent


### PR DESCRIPTION
This is required because we want to use these on alpine (using musl), so dynamically linking to the Ubuntu libc (glibc) must be avoided.