### PR TITLE
Allow containerd port binding removal after shutdown

### DIFF
--- a/pkg/containerd/events.go
+++ b/pkg/containerd/events.go
@@ -186,6 +186,8 @@ func (e *EventMonitor) IsServing(ctx context.Context) error {
 
 // Close closes the client connection to the API server.
 func (e *EventMonitor) Close() error {
+	e.portTracker.RemoveAll()
+
 	return e.containerdClient.Close()
 }
 


### PR DESCRIPTION
This PR allows cleanup of port mappings on the host machine after the shutdown of Rancher Desktop when containerd backend engine is in use. 

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/3007


Signed-off-by: Nino Kodabande <nkodabande@suse.com>