### PR TITLE
Watches for LoadBalancer service types

### DIFF
--- a/cmd/rancher-desktop-guestagent/main.go
+++ b/cmd/rancher-desktop-guestagent/main.go
@@ -168,7 +168,7 @@ func main() {
 	if *enableKubernetes {
 		group.Go(func() error {
 			// Watch for kube
-			err := kube.WatchForNodePortServices(ctx, tcpTracker, *configPath)
+			err := kube.WatchForServices(ctx, tcpTracker, *configPath)
 			if err != nil {
 				return fmt.Errorf("error watching services: %w", err)
 			}

--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -42,11 +42,10 @@ const (
 	stateWatching
 )
 
-// WatchForNodePortServices watches Kubernetes for NodePort services and create
-// listeners on 127.0.0.1 matching them.
-//
+// WatchServcies watches Kubernetes for NodePort and LoadBalancer services
+// and create listeners on 127.0.0.1 matching them.
 // Any connection errors are ignored and retried.
-func WatchForNodePortServices(ctx context.Context, tracker *tcplistener.ListenerTracker, configPath string) error {
+func WatchForServices(ctx context.Context, tracker *tcplistener.ListenerTracker, configPath string) error {
 	// These variables are shared across the different states
 	var (
 		state     = stateNoConfig


### PR DESCRIPTION
This allows watching for LoadBalancer service types along with NodePorts.

Signed-off-by: Nino Kodabande <nkodabande@suse.com>