### PR TITLE
Handle kubernetes port mappings

### DIFF
--- a/cmd/rancher-desktop-guestagent/main.go
+++ b/cmd/rancher-desktop-guestagent/main.go
@@ -147,6 +147,18 @@ func main() {
 				return nil
 			})
 		}
+
+		if *enableKubernetes {
+			group.Go(func() error {
+				// Watch for kube
+				err := kube.WatchForServices(ctx, tcpTracker, *configPath, portTracker)
+				if err != nil {
+					return fmt.Errorf("error watching services: %w", err)
+				}
+
+				return nil
+			})
+		}
 	}
 
 	if *enableIptables {
@@ -155,18 +167,6 @@ func main() {
 			err := iptables.ForwardPorts(ctx, tcpTracker, iptablesUpdateInterval)
 			if err != nil {
 				return fmt.Errorf("error mapping ports: %w", err)
-			}
-
-			return nil
-		})
-	}
-
-	if *enableKubernetes {
-		group.Go(func() error {
-			// Watch for kube
-			err := kube.WatchForServices(ctx, tcpTracker, *configPath)
-			if err != nil {
-				return fmt.Errorf("error watching services: %w", err)
 			}
 
 			return nil

--- a/pkg/docker/events.go
+++ b/pkg/docker/events.go
@@ -144,7 +144,7 @@ func (e *EventMonitor) initializeRunningContainers(ctx context.Context) error {
 			}
 
 			if err := e.portTracker.Add(container.ID, portMap); err != nil {
-				log.Errorf("registring already running containers failed: %v", err)
+				log.Errorf("registering already running containers failed: %v", err)
 			}
 		}
 	}
@@ -180,7 +180,7 @@ func createPortMapping(ports []types.Port) (nat.PortMap, error) {
 	return portMap, nil
 }
 
-// Removes entries in port mapping that do no hold any values
+// Removes entries in port mapping that do not hold any values
 // for IP and Port e.g 9000/tcp:[].
 func validatePortMapping(portMap nat.PortMap) {
 	for k, v := range portMap {

--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/Masterminds/log-go"
 	"github.com/rancher-sandbox/rancher-desktop-agent/pkg/tcplistener"
+	"github.com/rancher-sandbox/rancher-desktop-agent/pkg/tracker"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -45,7 +46,9 @@ const (
 // WatchServcies watches Kubernetes for NodePort and LoadBalancer services
 // and create listeners on 0.0.0.0 matching them.
 // Any connection errors are ignored and retried.
-func WatchForServices(ctx context.Context, tracker *tcplistener.ListenerTracker, configPath string) error {
+func WatchForServices(ctx context.Context, tracker *tcplistener.ListenerTracker, configPath string,
+	portTracker *tracker.PortTracker,
+) error {
 	// These variables are shared across the different states
 	var (
 		state     = stateNoConfig
@@ -100,7 +103,7 @@ func WatchForServices(ctx context.Context, tracker *tcplistener.ListenerTracker,
 				return fmt.Errorf("failed to create Kubernetes client: %w", err)
 			}
 
-			eventCh, errorCh, err = watchServices(watchContext, clientset)
+			eventCh, errorCh, err = watchServices(watchContext, clientset, portTracker)
 			if err != nil {
 				if isTimeout(err) {
 					// If it's a time out, the server may not be running yet


### PR DESCRIPTION
Handle kubernetes port mappings via PortTracker if a service is added, removed or edited.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/3093
Signed-off-by: Tatjana Dehler <tdehler@suse.com>