### PR TITLE
Adds json tag to port mapping types

### DIFF
--- a/pkg/types/README.md
+++ b/pkg/types/README.md
@@ -12,18 +12,18 @@ Below is the json schema for PortMapping:
   "$defs": {
     "ConnectAddrs": {
       "properties": {
-        "Network": {
+        "network": {
           "type": "string"
         },
-        "Addr": {
+        "addr": {
           "type": "string"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "Network",
-        "Addr"
+        "network",
+        "addr"
       ]
     },
     "PortBinding": {
@@ -55,13 +55,13 @@ Below is the json schema for PortMapping:
     },
     "PortMapping": {
       "properties": {
-        "Remove": {
+        "remove": {
           "type": "boolean"
         },
-        "Ports": {
+        "ports": {
           "$ref": "#/$defs/PortMap"
         },
-        "ConnectAddrs": {
+        "connectAddrs": {
           "items": {
             "$ref": "#/$defs/ConnectAddrs"
           },
@@ -71,9 +71,9 @@ Below is the json schema for PortMapping:
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "Remove",
-        "Ports",
-        "ConnectAddrs"
+        "remove",
+        "ports",
+        "connectAddrs"
       ]
     }
   }

--- a/pkg/types/portmapping.go
+++ b/pkg/types/portmapping.go
@@ -21,18 +21,18 @@ import "github.com/docker/go-connections/nat"
 // the Vtunnel to the RD Privileged Service.
 type PortMapping struct {
 	// Remvoe indicates wherethere to remove or add the entry
-	Remove bool
+	Remove bool `json:"remove"`
 	// Ports are the port mappings for both IPV4 and IPV6
-	Ports nat.PortMap
+	Ports nat.PortMap `json:"ports"`
 	// ConnectAddrs are the backend addresses to connect to
-	ConnectAddrs []ConnectAddrs
+	ConnectAddrs []ConnectAddrs `json:"connectAddrs"`
 }
 
 // ConnectAddrs represent the address for WSL interface
 // inside the VM, this address is usually available on eth0.
 type ConnectAddrs struct {
 	// Network indicates the available networks for the address (for example, "tcp", "udp")
-	Network string
+	Network string `json:"network"`
 	// Address is either IPV4 or IPV6 in CIDR format (for example, "192.0.2.1:25", "[2001:db8::1]:80")
-	Addr string
+	Addr string `json:"addr"`
 }


### PR DESCRIPTION
The update to the golangci-lint requires now to provide json tags for the portmapping types. 

Signed-off-by: Nino Kodabande <nkodabande@suse.com>