### PR TITLE
Fixes k8s service listener for non-admin install

### DIFF
--- a/pkg/tracker/porttracker.go
+++ b/pkg/tracker/porttracker.go
@@ -24,7 +24,9 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-agent/pkg/types"
 )
 
-// PortTracker mamanges published ports.
+// PortTracker keeps track of port mappings and forwards
+// them to the privileged service on the host over AF_VSOCK
+// tunnel (vtunnel).
 type PortTracker struct {
 	// For docker the key is container ID
 	portmap          map[string]nat.PortMap


### PR DESCRIPTION
Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4124

This will allow us to forward the port mappings to the `privilegedService` using the `portTracker` or using`listenerTracker` to start the listeners locally. Please note that I will be putting all these trackers in an interface to make the code cleaner in the future. https://github.com/rancher-sandbox/rancher-desktop-agent/issues/30