### PR TITLE
Consider all ports maps when handling update event

### DIFF
--- a/pkg/kube/servicewatcher.go
+++ b/pkg/kube/servicewatcher.go
@@ -153,9 +153,8 @@ func handleUpdate(oldObj, newObj interface{}, eventCh chan<- event) {
 				if _, ok := deleted[port.NodePort]; ok {
 					// This port is in both added & deleted; skip it.
 					delete(deleted, port.NodePort)
-				} else {
-					added[port.NodePort] = port.Protocol
 				}
+				added[port.NodePort] = port.Protocol
 			}
 		}
 
@@ -163,15 +162,17 @@ func handleUpdate(oldObj, newObj interface{}, eventCh chan<- event) {
 			for _, port := range newSvc.Spec.Ports {
 				if _, ok := deleted[port.Port]; ok {
 					delete(deleted, port.Port)
-				} else {
-					added[port.Port] = port.Protocol
 				}
+				added[port.Port] = port.Protocol
 			}
 		}
 	}
-
-	sendEvents(deleted, oldSvc, true, eventCh)
-	sendEvents(added, newSvc, false, eventCh)
+	if len(deleted) > 0 {
+		sendEvents(deleted, oldSvc, true, eventCh)
+	}
+	if len(added) > 0 {
+		sendEvents(added, newSvc, false, eventCh)
+	}
 
 	log.Debugf("kubernetes service update: %s/%s has -%d +%d service port",
 		namespace, name, len(deleted), len(added))

--- a/pkg/kube/servicewatcher.go
+++ b/pkg/kube/servicewatcher.go
@@ -150,26 +150,23 @@ func handleUpdate(oldObj, newObj interface{}, eventCh chan<- event) {
 
 		if newSvc.Spec.Type == corev1.ServiceTypeNodePort {
 			for _, port := range newSvc.Spec.Ports {
-				if _, ok := deleted[port.NodePort]; ok {
-					// This port is in both added & deleted; skip it.
-					delete(deleted, port.NodePort)
-				}
+				delete(deleted, port.NodePort)
 				added[port.NodePort] = port.Protocol
 			}
 		}
 
 		if newSvc.Spec.Type == corev1.ServiceTypeLoadBalancer {
 			for _, port := range newSvc.Spec.Ports {
-				if _, ok := deleted[port.Port]; ok {
-					delete(deleted, port.Port)
-				}
+				delete(deleted, port.Port)
 				added[port.Port] = port.Protocol
 			}
 		}
 	}
+
 	if len(deleted) > 0 {
 		sendEvents(deleted, oldSvc, true, eventCh)
 	}
+
 	if len(added) > 0 {
 		sendEvents(added, newSvc, false, eventCh)
 	}

--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -150,7 +150,7 @@ func WatchForServices(
 								"name":      event.name,
 							})
 						} else {
-							log.Debugf("kuberentes service: port mapping deleted %s/%s:%v",
+							log.Debugf("kubernetes service: port mapping deleted %s/%s:%v",
 								event.namespace, event.name, event.portMapping)
 						}
 
@@ -168,7 +168,7 @@ func WatchForServices(
 						}
 					}
 
-					log.Debugf("kuberentes service: deleted listener %s/%s:%v",
+					log.Debugf("kubernetes service: deleted listener %s/%s:%v",
 						event.namespace, event.name, event.portMapping)
 				} else {
 					if enablePrivilegedService {


### PR DESCRIPTION
As the `PortTracker.Add` method is actually a replace, we need to handle **all** added port maps, regardless of deleted port maps.

this change should fix #32 