### PR TITLE
Determine install type for RD Networking

### DIFF
--- a/cmd/rancher-desktop-guestagent/main.go
+++ b/cmd/rancher-desktop-guestagent/main.go
@@ -51,10 +51,11 @@ var (
 	containerdSock   = flag.String("containerdSock",
 		containerdSocketFile,
 		"file path for Containerd socket address")
-	vtunnelAddr             = flag.String("vtunnelAddr", vtunnelPeerAddr, "Peer address for Vtunnel in IP:PORT format")
+	vtunnelAddr             = flag.String("vtunnelAddr", vtunnelPeerAddr, "peer address for Vtunnel in IP:PORT format")
 	enablePrivilegedService = flag.Bool("privilegedService", false, "enable Privileged Service mode")
 	k8sServiceListenerAddr  = flag.String("k8sServiceListenerAddr", net.IPv4zero.String(),
 		"address to bind Kubernetes services to on the host, valid options are 0.0.0.0 or 127.0.0.1")
+	adminInstall = flag.Bool("adminInstall", false, "indicates if Rancher Desktop is installed as admin or not")
 )
 
 // Flags can only be enabled in the following combination:
@@ -95,7 +96,7 @@ func main() {
 
 	log.Current = logger
 
-	log.Info("Starting Rancher Desktop Agent")
+	log.Info("Starting Rancher Desktop Agent in [AdminInstall=%t] mode", *adminInstall)
 
 	if os.Geteuid() != 0 {
 		log.Fatal("agent must run as root")
@@ -140,7 +141,7 @@ func main() {
 		forwarder := forwarder.NewVTunnelForwarder(*vtunnelAddr)
 		portTracker = tracker.NewVTunnelTracker(forwarder, wslAddr)
 	} else {
-		portTracker = tracker.NewAPITracker(tracker.GatewayBaseURL)
+		portTracker = tracker.NewAPITracker(tracker.GatewayBaseURL, *adminInstall)
 	}
 
 	if *enableContainerd {


### PR DESCRIPTION
This PR introduces a new flag `adminInstall` that indicates whether RD is installed as admin. In the case of the non-admin install when Rancher Desktop Networking is enabled, we will always use the `127.0.0.1` (localhost) address to map published ports on the host. 

It depends on: https://github.com/rancher-sandbox/rancher-desktop/pull/4835