### PR TITLE
Fixes the nil pointer panic in kube watcher

### DIFF
--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -239,12 +239,14 @@ func getClientConfig(configPath string) (*restclient.Config, error) {
 }
 
 func isTimeout(err error) bool {
-	var timeoutError interface {
+	type timeout interface {
 		Timeout() bool
 	}
 
+	var timeoutError timeout
+
 	if !errors.As(err, &timeoutError) {
-		return timeoutError.Timeout()
+		return timeoutError != nil && timeoutError.Timeout()
 	}
 
 	return false


### PR DESCRIPTION
Partially fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/5126