### PR TITLE
Try to ensure that we exit when the context is closed

### DIFF
--- a/pkg/iptables/portmap.go
+++ b/pkg/iptables/portmap.go
@@ -65,6 +65,12 @@ func ForwardPorts(ctx context.Context, tracker tracker.Tracker, updateInterval t
 			}
 		}
 
+		select {
+		case <-ctx.Done():
+			return nil
+		default: // continue the loop
+		}
+
 		// Wait for next loop
 		time.Sleep(updateInterval)
 	}

--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -135,6 +135,12 @@ func WatchForServices(
 			state = stateWatching
 		case stateWatching:
 			select {
+			case <-ctx.Done():
+				log.Debugw("kubernetes watcher: context closed", log.Fields{
+					"error": ctx.Err(),
+				})
+
+				return ctx.Err()
 			case err = <-errorCh:
 				log.Debugw("kubernetes: got error, rolling back", log.Fields{
 					"error": err,


### PR DESCRIPTION
In the various infinite loops that wait for things to happen, ensure that we check the context and exit if the context is done.  This means that when the process receives SIGTERM (which we catch and handle), we actually exit the application rather than running forever.

This is required for `rc-service rancher-desktop-agent stop` etc.

I ran `make fmt/lint/test`, but I do not recall if there are more tests I should try.