### PR TITLE
pkg/tracker: Don't re-all existing listeners

### DIFF
--- a/pkg/tracker/listenertracker.go
+++ b/pkg/tracker/listenertracker.go
@@ -46,6 +46,16 @@ func NewListenerTracker() *ListenerTracker {
 func (l *ListenerTracker) AddListener(ctx context.Context, ip net.IP, port int) error {
 	addr := ipPortToAddr(ip, port)
 
+	var oldListener net.Listener
+
+	l.mutex.Lock()
+	oldListener = l.listeners[addr]
+	l.mutex.Unlock()
+
+	if oldListener != nil {
+		return nil
+	}
+
 	listener, err := listen(ctx, addr)
 	if err != nil {
 		return err


### PR DESCRIPTION
`ListenerTracker.AddListener` is documented to be a no-op if the given IP / port combination was already tracked.  However, the implementation didn't do that, so we ended up opening up multiple listeners on the same port (and dropping the old listeners on the floor, never closing them).

This seems to fix an issue I have with `traefik.bats` in `disable traefik` → `no connection on localhost`, but `curl traefik via localhost` and `curl traefik via host-ip while kubernetes.ingress.localhost-only is false` still fail for me.  Are those tests assuming privileged service or something?