### PR TITLE
Run the iptable rule for localhost during container initialization

### DIFF
--- a/pkg/docker/events.go
+++ b/pkg/docker/events.go
@@ -160,6 +160,16 @@ func (e *EventMonitor) initializeRunningContainers(ctx context.Context) error {
 			if err := e.portTracker.Add(container.ID, portMap); err != nil {
 				log.Errorf("registering already running containers failed: %v", err)
 			}
+
+			for _, netSettings := range container.NetworkSettings.Networks {
+				err = createLoopbackIPtablesRules(
+					netSettings.IPAddress,
+					portMap)
+
+				if err != nil {
+					log.Errorf("failed running iptable rules to update DNAT rule in DOCKER chain: %v", err)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
During the container initialization we were not running the [iptable rules](https://github.com/rancher-sandbox/rancher-desktop-agent/blob/130b4f5b4bb9cfc22b4e85d5533f6ab0e17e3dcb/pkg/docker/events.go#L219) for the container that were mapped to the localhost. 

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/5396