### PR TITLE
Add wsl-proxy forwarder

### DIFF
--- a/cmd/rancher-desktop-guestagent/main.go
+++ b/cmd/rancher-desktop-guestagent/main.go
@@ -141,7 +141,8 @@ func main() {
 		forwarder := forwarder.NewVTunnelForwarder(*vtunnelAddr)
 		portTracker = tracker.NewVTunnelTracker(forwarder, wslAddr)
 	} else {
-		portTracker = tracker.NewAPITracker(tracker.GatewayBaseURL, *adminInstall)
+		forwarder := forwarder.NewWSLProxyForwarder("/run/wsl-proxy.sock")
+		portTracker = tracker.NewAPITracker(forwarder, tracker.GatewayBaseURL, *adminInstall)
 	}
 
 	if *enableContainerd {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 )
 
 require (
-	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.10.0-rc.1 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
@@ -55,7 +54,6 @@ require (
 	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/ginkgo/v2 v2.9.2 // indirect
 	github.com/onsi/gomega v1.27.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -291,7 +291,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=

--- a/pkg/forwarder/wslproxy.go
+++ b/pkg/forwarder/wslproxy.go
@@ -1,0 +1,59 @@
+/*
+Copyright © 2024 SUSE LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package forwarder implements a forwarding mechanism to forward
+// port mappings to Rancher Desktop WSL Proxy.
+package forwarder
+
+import (
+	"encoding/json"
+	"net"
+
+	"github.com/rancher-sandbox/rancher-desktop-agent/pkg/types"
+)
+
+/*
+This package provides functionality to forward port mappings to the
+Rancher Desktop WSL Proxy process in the default namespace over a Unix socket.
+
+For more information on Rancher Desktop WSL Proxy, refer to the source code at:
+https://github.com/rancher-sandbox/rancher-desktop-networking/blob/main/cmd/proxy/wsl_integration_linux.go
+*/
+
+// WSLProxyForwarder forwards the PortMappings to Rancher Desktop WSLProxy process in
+// the default namespace over the unix socket.
+type WSLProxyForwarder struct {
+	proxySocket string
+}
+
+func NewWSLProxyForwarder(proxySocket string) *WSLProxyForwarder {
+	return &WSLProxyForwarder{
+		proxySocket: proxySocket,
+	}
+}
+
+// Send forwards the port mappings to WSL Proxy.
+func (v *WSLProxyForwarder) Send(portMapping types.PortMapping) error {
+	conn, err := net.Dial("unix", v.proxySocket)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	err = json.NewEncoder(conn).Encode(portMapping)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/forwarder/wslproxy.go
+++ b/pkg/forwarder/wslproxy.go
@@ -22,16 +22,10 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-agent/pkg/types"
 )
 
-/*
-This package provides functionality to forward port mappings to the
-Rancher Desktop WSL Proxy process in the default namespace over a Unix socket.
-
-For more information on Rancher Desktop WSL Proxy, refer to the source code at:
-https://github.com/rancher-sandbox/rancher-desktop-networking/blob/main/cmd/proxy/wsl_integration_linux.go
-*/
-
 // WSLProxyForwarder forwards the PortMappings to Rancher Desktop WSLProxy process in
 // the default namespace over the unix socket.
+// For more information on Rancher Desktop WSL Proxy, refer to the source code at:
+// https://github.com/rancher-sandbox/rancher-desktop-networking/blob/main/cmd/proxy/wsl_integration_linux.go
 type WSLProxyForwarder struct {
 	proxySocket string
 }

--- a/pkg/tracker/apitracker_test.go
+++ b/pkg/tracker/apitracker_test.go
@@ -53,7 +53,8 @@ func TestBasicAdd(t *testing.T) {
 	testSrv := httptest.NewServer(mux)
 	defer testSrv.Close()
 
-	apiTracker := tracker.NewAPITracker(testSrv.URL, true)
+	forwarder := testForwarder{}
+	apiTracker := tracker.NewAPITracker(&forwarder, testSrv.URL, true)
 	portMapping := nat.PortMap{
 		"80/tcp": []nat.PortBinding{
 			{
@@ -89,7 +90,8 @@ func TestAddOverride(t *testing.T) {
 	testSrv := httptest.NewServer(mux)
 	defer testSrv.Close()
 
-	apiTracker := tracker.NewAPITracker(testSrv.URL, true)
+	forwarder := testForwarder{}
+	apiTracker := tracker.NewAPITracker(&forwarder, testSrv.URL, true)
 	portMapping := nat.PortMap{
 		"80/tcp": []nat.PortBinding{
 			{
@@ -180,7 +182,8 @@ func TestAddWithError(t *testing.T) {
 	testSrv := httptest.NewServer(mux)
 	defer testSrv.Close()
 
-	apiTracker := tracker.NewAPITracker(testSrv.URL, true)
+	forwarder := testForwarder{}
+	apiTracker := tracker.NewAPITracker(&forwarder, testSrv.URL, true)
 	portMapping := nat.PortMap{
 		"80/tcp": []nat.PortBinding{
 			{
@@ -275,7 +278,8 @@ func TestGet(t *testing.T) {
 	testSrv := httptest.NewServer(mux)
 	defer testSrv.Close()
 
-	apiTracker := tracker.NewAPITracker(testSrv.URL, true)
+	forwarder := testForwarder{}
+	apiTracker := tracker.NewAPITracker(&forwarder, testSrv.URL, true)
 	err := apiTracker.Add(containerID, portMapping)
 	require.NoError(t, err)
 
@@ -303,7 +307,8 @@ func TestRemove(t *testing.T) {
 	testSrv := httptest.NewServer(mux)
 	defer testSrv.Close()
 
-	apiTracker := tracker.NewAPITracker(testSrv.URL, true)
+	forwarder := testForwarder{}
+	apiTracker := tracker.NewAPITracker(&forwarder, testSrv.URL, true)
 	portMapping1 := nat.PortMap{
 		"80/tcp": []nat.PortBinding{
 			{
@@ -367,7 +372,8 @@ func TestRemoveWithError(t *testing.T) {
 	testSrv := httptest.NewServer(mux)
 	defer testSrv.Close()
 
-	apiTracker := tracker.NewAPITracker(testSrv.URL, true)
+	forwarder := testForwarder{}
+	apiTracker := tracker.NewAPITracker(&forwarder, testSrv.URL, true)
 
 	portMapping := nat.PortMap{
 		"80/tcp": []nat.PortBinding{
@@ -427,7 +433,8 @@ func TestRemoveAll(t *testing.T) {
 	testSrv := httptest.NewServer(mux)
 	defer testSrv.Close()
 
-	apiTracker := tracker.NewAPITracker(testSrv.URL, true)
+	forwarder := testForwarder{}
+	apiTracker := tracker.NewAPITracker(&forwarder, testSrv.URL, true)
 
 	portMapping1 := nat.PortMap{
 		"80/tcp": []nat.PortBinding{
@@ -491,7 +498,8 @@ func TestRemoveAllWithError(t *testing.T) {
 	testSrv := httptest.NewServer(mux)
 	defer testSrv.Close()
 
-	apiTracker := tracker.NewAPITracker(testSrv.URL, true)
+	forwarder := testForwarder{}
+	apiTracker := tracker.NewAPITracker(&forwarder, testSrv.URL, true)
 
 	portMapping1 := nat.PortMap{
 		"80/tcp": []nat.PortBinding{
@@ -571,7 +579,8 @@ func TestNonAdminInstall(t *testing.T) {
 	testSrv := httptest.NewServer(mux)
 	defer testSrv.Close()
 
-	apiTracker := tracker.NewAPITracker(testSrv.URL, false)
+	forwarder := testForwarder{}
+	apiTracker := tracker.NewAPITracker(&forwarder, testSrv.URL, false)
 
 	portMapping := nat.PortMap{
 		"1025/tcp": []nat.PortBinding{

--- a/pkg/tracker/vtunneltracker_test.go
+++ b/pkg/tracker/vtunneltracker_test.go
@@ -30,7 +30,7 @@ func TestVTunnelTrackerAdd(t *testing.T) {
 	t.Parallel()
 
 	wslConnectAddr := []types.ConnectAddrs{{Network: "tcp", Addr: "192.168.0.1"}}
-	forwarder := testVTunnelForwarder{}
+	forwarder := testForwarder{}
 	vtunnelTracker := tracker.NewVTunnelTracker(&forwarder, wslConnectAddr)
 
 	portMapping := nat.PortMap{
@@ -79,7 +79,7 @@ func TestVTunnelTrackerAddOverride(t *testing.T) {
 	t.Parallel()
 
 	wslConnectAddr := []types.ConnectAddrs{{Network: "tcp", Addr: "192.168.0.1"}}
-	forwarder := testVTunnelForwarder{}
+	forwarder := testForwarder{}
 	vtunnelTracker := tracker.NewVTunnelTracker(&forwarder, wslConnectAddr)
 
 	portMapping := nat.PortMap{
@@ -146,7 +146,7 @@ func TestVTunnelTrackerAddEmptyPortMap(t *testing.T) {
 	t.Parallel()
 
 	wslConnectAddr := []types.ConnectAddrs{{Network: "tcp", Addr: "192.168.0.1"}}
-	forwarder := testVTunnelForwarder{}
+	forwarder := testForwarder{}
 	forwarder.sendErr = errSend
 	vtunnelTracker := tracker.NewVTunnelTracker(&forwarder, wslConnectAddr)
 
@@ -164,7 +164,7 @@ func TestVTunnelTrackerAddWithError(t *testing.T) {
 	t.Parallel()
 
 	wslConnectAddr := []types.ConnectAddrs{{Network: "tcp", Addr: "192.168.0.1"}}
-	forwarder := testVTunnelForwarder{}
+	forwarder := testForwarder{}
 	forwarder.sendErr = errSend
 	vtunnelTracker := tracker.NewVTunnelTracker(&forwarder, wslConnectAddr)
 
@@ -196,7 +196,7 @@ func TestVTunnelTrackerRemove(t *testing.T) {
 	t.Parallel()
 
 	wslConnectAddr := []types.ConnectAddrs{{Network: "tcp", Addr: "192.168.0.1"}}
-	forwarder := testVTunnelForwarder{}
+	forwarder := testForwarder{}
 	vtunnelTracker := tracker.NewVTunnelTracker(&forwarder, wslConnectAddr)
 
 	portMapping := nat.PortMap{
@@ -252,7 +252,7 @@ func TestVTunnelTrackerRemoveZeroLengthPortMap(t *testing.T) {
 	t.Parallel()
 
 	wslConnectAddr := []types.ConnectAddrs{{Network: "tcp", Addr: "192.168.0.1"}}
-	forwarder := testVTunnelForwarder{}
+	forwarder := testForwarder{}
 	vtunnelTracker := tracker.NewVTunnelTracker(&forwarder, wslConnectAddr)
 
 	portMapping := nat.PortMap{}
@@ -267,7 +267,7 @@ func TestVTunnelTrackerRemoveError(t *testing.T) {
 	t.Parallel()
 
 	wslConnectAddr := []types.ConnectAddrs{{Network: "tcp", Addr: "192.168.0.1"}}
-	forwarder := testVTunnelForwarder{}
+	forwarder := testForwarder{}
 	vtunnelTracker := tracker.NewVTunnelTracker(&forwarder, wslConnectAddr)
 
 	portMapping := nat.PortMap{
@@ -331,7 +331,7 @@ func TestVTunnelTrackerRemoveAll(t *testing.T) {
 	t.Parallel()
 
 	wslConnectAddr := []types.ConnectAddrs{{Network: "tcp", Addr: "192.168.0.1"}}
-	forwarder := testVTunnelForwarder{}
+	forwarder := testForwarder{}
 	vtunnelTracker := tracker.NewVTunnelTracker(&forwarder, wslConnectAddr)
 
 	portMapping := nat.PortMap{
@@ -393,7 +393,7 @@ func TestVTunnelTrackerRemoveAllError(t *testing.T) {
 	t.Parallel()
 
 	wslConnectAddr := []types.ConnectAddrs{{Network: "tcp", Addr: "192.168.0.1"}}
-	forwarder := testVTunnelForwarder{}
+	forwarder := testForwarder{}
 	vtunnelTracker := tracker.NewVTunnelTracker(&forwarder, wslConnectAddr)
 
 	portMapping := nat.PortMap{
@@ -460,7 +460,7 @@ func TestVTunnelTrackerGet(t *testing.T) {
 	t.Parallel()
 
 	wslConnectAddr := []types.ConnectAddrs{{Network: "tcp", Addr: "192.168.0.1"}}
-	forwarder := testVTunnelForwarder{}
+	forwarder := testForwarder{}
 	vtunnelTracker := tracker.NewVTunnelTracker(&forwarder, wslConnectAddr)
 
 	portMapping := nat.PortMap{
@@ -480,13 +480,13 @@ func TestVTunnelTrackerGet(t *testing.T) {
 
 var errSend = errors.New("error from Send")
 
-type testVTunnelForwarder struct {
+type testForwarder struct {
 	receivedPortMappings []types.PortMapping
 	sendErr              error
 	failCondition        func(types.PortMapping) error
 }
 
-func (v *testVTunnelForwarder) Send(portMapping types.PortMapping) error {
+func (v *testForwarder) Send(portMapping types.PortMapping) error {
 	if v.failCondition != nil {
 		if err := v.failCondition(portMapping); err != nil {
 			return err


### PR DESCRIPTION
This change introduces the wsl proxy forwarder, the forwarder is responsible for forwarding all the port binding events from docker, containerd, and kubernetes over the UNIX socket to wsl-proxy process that runs outside of the namespace in the default namespace. The wsl proxy forwarder implements a forwarder interface so that it is easily integrated able into the corresponding tracker, e.g. apitracker (which is used for the network namespace).

Related: https://github.com/rancher-sandbox/rancher-desktop/issues/6636