### PR TITLE
Fixes the wrong use of k8s client-go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,9 @@ linters:
     - dupword # It interferes with duplicate words in comments
     - wsl
 linters-settings:
+  mnd:
+    ignored-functions:
+    - "net.IPv4"
   govet:
     disable:
     - lostcancel # Not tracking cancel usage correctly.

--- a/cmd/rancher-desktop-guestagent/main.go
+++ b/cmd/rancher-desktop-guestagent/main.go
@@ -181,7 +181,7 @@ func main() {
 			k8sServiceListenerIP := net.ParseIP(*k8sServiceListenerAddr)
 
 			if k8sServiceListenerIP == nil || !(k8sServiceListenerIP.Equal(net.IPv4zero) ||
-				k8sServiceListenerIP.Equal(net.IPv4(127, 0, 0, 1))) { //nolint:gomnd,mnd // IPv4 addr localhost
+				k8sServiceListenerIP.Equal(net.IPv4(127, 0, 0, 1))) {
 				log.Fatalf("empty or none valid input for Kubernetes service listener IP address %s. "+
 					"Valid options are 0.0.0.0 and 127.0.0.1.", *k8sServiceListenerAddr)
 			}

--- a/cmd/rancher-desktop-guestagent/main.go
+++ b/cmd/rancher-desktop-guestagent/main.go
@@ -181,7 +181,7 @@ func main() {
 			k8sServiceListenerIP := net.ParseIP(*k8sServiceListenerAddr)
 
 			if k8sServiceListenerIP == nil || !(k8sServiceListenerIP.Equal(net.IPv4zero) ||
-				k8sServiceListenerIP.Equal(net.IPv4(127, 0, 0, 1))) { //nolint:gomnd // IPv4 addr localhost
+				k8sServiceListenerIP.Equal(net.IPv4(127, 0, 0, 1))) { //nolint:gomnd,mnd // IPv4 addr localhost
 				log.Fatalf("empty or none valid input for Kubernetes service listener IP address %s. "+
 					"Valid options are 0.0.0.0 and 127.0.0.1.", *k8sServiceListenerAddr)
 			}

--- a/pkg/kube/servicewatcher.go
+++ b/pkg/kube/servicewatcher.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/sys/unix"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -48,14 +48,17 @@ func watchServices(ctx context.Context, client *kubernetes.Clientset) (<-chan ev
 	informerFactory := informers.NewSharedInformerFactory(client, 1*time.Hour)
 	serviceInformer := informerFactory.Core().V1().Services()
 	sharedInformer := serviceInformer.Informer()
-	_, _ = sharedInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
+			log.Debugf("Service Informer: Add func called with: %+v", obj)
 			handleUpdate(nil, obj, eventCh)
 		},
 		DeleteFunc: func(obj interface{}) {
+			log.Debugf("Service Informer: Del func called with: %+v", obj)
 			handleUpdate(obj, nil, eventCh)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
+			log.Debugf("Service Informer: Update func called with old object %+v and new Object: %+v", oldObj, newObj)
 			handleUpdate(oldObj, newObj, eventCh)
 		},
 	})
@@ -101,15 +104,16 @@ func watchServices(ctx context.Context, client *kubernetes.Clientset) (<-chan ev
 	informerFactory.WaitForCacheSync(ctx.Done())
 	informerFactory.Start(ctx.Done())
 
-	services, err := serviceInformer.Lister().List(labels.Everything())
+	services, err := client.CoreV1().Services(corev1.NamespaceAll).List(ctx, v1.ListOptions{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("error listing services: %w", err)
 	}
+	log.Debugf("coreV1 services list :%+v", services.Items)
 
 	// List the initial set of services asynchronously, so that we don't have to
 	// worry about the channel blocking.
 	go func() {
-		for _, svc := range services {
+		for _, svc := range services.Items {
 			handleUpdate(nil, svc, eventCh)
 		}
 	}()

--- a/pkg/kube/servicewatcher.go
+++ b/pkg/kube/servicewatcher.go
@@ -48,7 +48,7 @@ func watchServices(ctx context.Context, client *kubernetes.Clientset) (<-chan ev
 	informerFactory := informers.NewSharedInformerFactory(client, 1*time.Hour)
 	serviceInformer := informerFactory.Core().V1().Services()
 	sharedInformer := serviceInformer.Informer()
-	_, _ = serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = sharedInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			log.Debugf("Service Informer: Add func called with: %+v", obj)
 			handleUpdate(nil, obj, eventCh)

--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -123,20 +123,17 @@ func WatchForServices(
 			eventCh, errorCh, err = watchServices(watchContext, clientset)
 			if err != nil {
 				switch {
-				case isTimeout(err):
-					fallthrough
-				case errors.Is(err, unix.ENETUNREACH):
-					fallthrough
-				case errors.Is(err, unix.ECONNREFUSED):
-					fallthrough
-				case isAPINotReady(err):
-					// sleep and continue for all the expected case
-					time.Sleep(time.Second)
-
-					continue
 				default:
 					return err
+				case isTimeout(err):
+				case errors.Is(err, unix.ENETUNREACH):
+				case errors.Is(err, unix.ECONNREFUSED):
+				case isAPINotReady(err):
 				}
+				// sleep and continue for all the expected case
+				time.Sleep(time.Second)
+
+				continue
 			}
 
 			log.Debugf("watching kubernetes services")
@@ -267,6 +264,10 @@ func isTimeout(err error) bool {
 	return false
 }
 
+// This is a k3s error that is received over
+// the HTTP, Also, it is worth noting that this
+// error is wrapped. This is why we are not testing
+// against the real error object using errors.Is().
 func isAPINotReady(err error) bool {
 	return strings.Contains(err.Error(), "apiserver not ready")
 }


### PR DESCRIPTION
Previously we were using the client incorrectly by not passing the context, this was causing internal network errors in the client due to the API server not being ready as you can see in the below logs:
```
2024/05/03 09:03:12 [DEBUG]   list of services from core v1----> []
W0503 09:03:12.649264     255 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:169: failed to list *v1.Service: Get "https://127.0.0.1:6443/api/v1/services?limit=500&resourceVersion=0": dial tcp 127.0.0.1:6443: connect: network is unreachable
2024/05/03 09:03:12 [DEBUG]   watching kubernetes services
2024/05/03 09:03:12 [DEBUG]   inside state watching
2024/05/03 09:03:12 [DEBUG]   kubernetes: error watching [error=failed to list *v1.Service: Get "https://127.0.0.1:6443/api/v1/services?limit=500&resourceVersion=0": dial tcp 127.0.0.1:6443: connect: network is unreachable]
2024/05/03 09:03:12 [ERROR]   kubernetes: unexpected error watching [error=failed to list *v1.Service: Get "https://127.0.0.1:6443/api/v1/services?limit=500&resourceVersion=0": dial tcp 127.0.0.1:6443: connect: network is unreachable]
W0503 09:03:14.012174     255 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.2/tools/cache/reflector.go:169: failed to list *v1.Service: Get "https://127.0.0.1:6443/api/v1/services?limit=500&resourceVersion=0": dial tcp 127.0.0.1:6443: connect: connection refused
2024/05/03 09:03:14 [DEBUG]   kubernetes: error watching [error=failed to list *v1.Service: Get "https://127.0.0.1:6443/api/v1/services?limit=500&resourceVersion=0": dial tcp 127.0.0.1:6443: connect: connection refused]
2024/05/03 09:03:14 [DEBUG]   kubernetes: got error, rolling back [error=failed to list *v1.Service: Get "https://127.0.0.1:6443/api/v1/services?limit=500&resourceVersion=0": dial tcp 127.0.0.1:6443: connect: connection refused]
2024/05/03 09:03:15 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
```
 However, we continued and blocked the event channel. 

With the new approach, we can determine when the API server is ready, this way we return a FATAL error and the process exists. This allows the init process to retry again until the API server becomes ready.

The below logs are for the the new approach:

```
2024/05/03 09:29:58 [INFO]    Starting Rancher Desktop Agent in [AdminInstall=true] mode
2024/05/03 09:29:58 [DEBUG]   kubernetes: loaded kubeconfig /etc/rancher/k3s/k3s.yaml
2024/05/03 09:29:58 [FATAL]   error watching services: error listing services: Get "https://127.0.0.1:6443/api/v1/services": dial tcp 127.0.0.1:6443: connect: network is unreachable
2024/05/03 09:30:03 [INFO]    Starting Rancher Desktop Agent in [AdminInstall=true] mode
2024/05/03 09:30:03 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:04 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:05 [DEBUG]   kubernetes: failed to read kubeconfig [error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory][config-path=/etc/rancher/k3s/k3s.yaml]
2024/05/03 09:30:06 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:07 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:08 [DEBUG]   checking if container engine API is running at /var/run/docker.sock
2024/05/03 09:30:08 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:09 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:10 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:11 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:12 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:13 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:14 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:15 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:16 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:17 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:18 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:19 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:20 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:21 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:22 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:23 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:24 [DEBUG]   kubernetes: failed to read kubeconfig [config-path=/etc/rancher/k3s/k3s.yaml][error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory]
2024/05/03 09:30:25 [DEBUG]   kubernetes: failed to read kubeconfig [error=could not load Kubernetes client config from /etc/rancher/k3s/k3s.yaml: stat /etc/rancher/k3s/k3s.yaml: no such file or directory][config-path=/etc/rancher/k3s/k3s.yaml]
2024/05/03 09:30:26 [DEBUG]   kubernetes: loaded kubeconfig /etc/rancher/k3s/k3s.yaml
2024/05/03 09:30:26 [ERROR]   context cancellation: context canceled
2024/05/03 09:30:26 [FATAL]   error watching services: error listing services: apiserver not ready
2024/05/03 09:30:31 [INFO]    Starting Rancher Desktop Agent in [AdminInstall=true] mode
2024/05/03 09:30:31 [DEBUG]   kubernetes: loaded kubeconfig /etc/rancher/k3s/k3s.yaml
```

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/6809